### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Lista_06_CodingBat.py
+++ b/Lista_06_CodingBat.py
@@ -83,8 +83,7 @@ def test(obtido, esperado):
     prefixo = ' Parabéns!'
   else:
     prefixo = ' Ainda não'
-  print ('%s obtido: %s esperado: %s'
-         % (prefixo, repr(obtido), repr(esperado)))
+  print ('{0!s} obtido: {1!s} esperado: {2!s}'.format(prefixo, repr(obtido), repr(esperado)))
 
 def main():
   print ('Oba! Hoje vou ficar dormindo!')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:davilaedu:teste_exercicos?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:davilaedu:teste_exercicos?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
